### PR TITLE
Update lgtm.yml configuration

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -20,13 +20,12 @@ extraction:
             - export GIT=true
         configure:
             command:
-                - pushd $LGTM_WORKSPACE
-                - $LGTM_SRC/prepare_deps
-                - popd
-                - export BOOST_DIR=$LGTM_WORKSPACE/boost
-                - export GTEST_DIR=$LGTM_WORKSPACE/googletest
-                - export HUNSPELL_DIR=$LGTM_WORKSPACE/hunspell
-                - export CRYPTOPP_DIR=$LGTM_WORKSPACE/cryptopp
+                - ./prepare_deps
+        before_index:
+            - export BOOST_DIR=$LGTM_SRC/boost
+            - export GTEST_DIR=$LGTM_SRC/googletest
+            - export HUNSPELL_DIR=$LGTM_SRC/hunspell
+            - export CRYPTOPP_DIR=$LGTM_SRC/cryptopp
         index:
             build_command:
                 - $GNU_MAKE -k


### PR DESCRIPTION
* Remove use of `LGTM_WORKSPACE` for calling `prepare_deps`. The paths in that script expected the current working directory to be the repository and it works fine this way.
* Move export of environment variables to the `before_index` section. The `configure` section is run in a separate step so they weren't available to the build command.